### PR TITLE
Support Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "guzzlehttp/guzzle": "~5.3|~6.0"
+        "guzzlehttp/guzzle": "~5.3|~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel 8 requires a baseline Guzzle 7 support.
Checked on https://github.com/guzzle/guzzle/blob/master/UPGRADING.md for breaking changes, but can't see any here.